### PR TITLE
change 3 links to their respective redirect link

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -31,11 +31,11 @@
 <footer class="site-footer grid-4q" aria-label="Site">
   <div class="q1-start q3-end about">
     <div>
-      <p><a class="largelink" href="https://w3.org/WAI/" lang="en" dir="auto" translate="no">W3C Web Accessibility Initiative (WAI)</a></p>
+      <p><a class="largelink" href="https://www.w3.org/WAI/" lang="en" dir="auto" translate="no">W3C Web Accessibility Initiative (WAI)</a></p>
       <p>{% include t.html t="Strategies, standards, and supporting resources to make the Web accessible to people with disabilities." %}</p>
     </div>
     <div lang="en" dir="auto" {% if site.data.lang[pagelang].rtl %}style="text-align: right;"{% endif %} translate="no">
-      <p>Copyright &#xA9; {{ 'now' | date: "%Y" }} W3C <sup>&#xAE;</sup> (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>) <a href="{{ "/about/using-wai-material/" | relative_url }}">Permission to Use WAI Material</a>.</p>
+      <p>Copyright &#xA9; {{ 'now' | date: "%Y" }} W3C <sup>&#xAE;</sup> (<a href="https://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="https://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>) <a href="{{ "/about/using-wai-material/" | relative_url }}">Permission to Use WAI Material</a>.</p>
     </div>
   </div>
   <div class="q4-start q4-end">


### PR DESCRIPTION
http://validator.w3.org/checklink?check=Check&hide_type=all&summary=on&uri=https%3A%2F%2Fwww.w3.org%2FWAI%2Fpeople-use-web%2Ftools-techniques%2Ffr%23stories-related-to-perception

 List of redirects

The links below are not broken, but the document does not use the exact URL, and the links were redirected. It may be a good idea to link to the final location, for the sake of speed.

warning Line: 637 http://www.csail.mit.edu/ redirected to https://www.csail.mit.edu/
    Status: 301 -> 200 OK

    This is a permanent redirect. The link should be updated. 
warning Line: 637 http://www.ercim.eu/ redirected to https://www.ercim.eu/
    Status: 301 -> 200 OK

    This is a permanent redirect. The link should be updated. 
warning Line: 633 https://w3.org/WAI/ redirected to https://www.w3.org/WAI/
    Status: 301 -> 200 OK

    This is a permanent redirect. The link should be updated.